### PR TITLE
replace google dns with cloudflare in secrets example

### DIFF
--- a/src/secrets.example.h
+++ b/src/secrets.example.h
@@ -18,7 +18,7 @@ const char* wifi_SSID_ALT_2 = "Helsingin kaupungin WLAN"; // Tertiary passwordle
 const IPAddress localIp(10,0,0,200);
 const IPAddress gatewayIp(10,0,0,1); 
 const IPAddress subnetIp(255,255,255,0);
-const IPAddress dnsIp(8,8,8,8);
+const IPAddress dnsIp(1,1,1,1);
 
 // AES Encryption Key
 const byte aes_key[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };

--- a/src/secrets.example.h
+++ b/src/secrets.example.h
@@ -18,7 +18,7 @@ const char* wifi_SSID_ALT_2 = "Helsingin kaupungin WLAN"; // Tertiary passwordle
 const IPAddress localIp(10,0,0,200);
 const IPAddress gatewayIp(10,0,0,1); 
 const IPAddress subnetIp(255,255,255,0);
-const IPAddress dnsIp(1,1,1,1);
+const IPAddress dnsIp(127,0,0,1);
 
 // AES Encryption Key
 const byte aes_key[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };


### PR DESCRIPTION
A minor optimization suggestion. As pointed out in README, DNS resolution takes time. In Helsinki, Cloudflare DNS should have smaller latency than Google. And perhaps more importantly, it's a little less data to the Google empire ;)